### PR TITLE
Add option for extra args to be passed to bintray api for Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ Example:
 API:
 
 ```Go
-    UploadFile(subject, repository, pkg, version, projectGroupId, projectName, filePath string, mavenRepo bool) error
+    UploadFile(subject, repository, pkg, version, projectGroupId, projectName, filePath, extraArgs string, mavenRepo bool) error
 ```
 
 Example:
 
 ```Go
-    err := client.UploadFile("subject", "repository", "pkg", "1.2", "", "", "testdata/01.txt", false)
+    err := client.UploadFile("subject", "repository", "pkg", "1.2", "", "", "testdata/01.txt", "", false)
     if err != nil {
         t.Errorf("unexpected error thrown %s", err)
     }

--- a/bintray/bintray_test.go
+++ b/bintray/bintray_test.go
@@ -181,7 +181,7 @@ func TestUploadFile(t *testing.T) {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"A":"a"}`)
 	})
-	err := client.UploadFile("subject", "repository", "pkg", "1.2", "", "", "testdata/01.txt", false)
+	err := client.UploadFile("subject", "repository", "pkg", "1.2", "", "", "testdata/01.txt", "", false)
 	if err != nil {
 		t.Errorf("unexpected error thrown %s", err)
 	}

--- a/bintray/client.go
+++ b/bintray/client.go
@@ -121,7 +121,7 @@ func (c *BintrayClient) executeCreateVersion(subject, repository, pkg, version s
 }
 
 //PUT /content/:subject/:repo/:package/:version/:path
-func (c *BintrayClient) UploadFile(subject, repository, pkg, version, projectGroupId, projectName, filePath string, mavenRepo bool) error {
+func (c *BintrayClient) UploadFile(subject, repository, pkg, version, projectGroupId, projectName, filePath, extraArgs string, mavenRepo bool) error {
 	fullPath, _ := filepath.Abs(filePath)
 	var entityPath string
 	var uploadUrl string
@@ -131,7 +131,7 @@ func (c *BintrayClient) UploadFile(subject, repository, pkg, version, projectGro
 		uploadUrl = "content/" + subject + "/" + repository + "/" + pkg + "/" + version + "/" + entityPath
 	} else {
 		entityPath = version + "/" + fileName
-		uploadUrl = "content/" + subject + "/" + repository + "/" + pkg + "/" + entityPath
+		uploadUrl = "content/" + subject + "/" + repository + "/" + pkg + "/" + entityPath + extraArgs
 	}
 	file, err := os.Open(fullPath)
 	if err != nil {


### PR DESCRIPTION
This makes is possible to publish Debian packages with this client. https://bintray.com/docs/api/#_debian_upload
